### PR TITLE
26 todo list.item count default closes #26

### DIFF
--- a/db/migrate/20160305022243_change_item_count_default_to_0.rb
+++ b/db/migrate/20160305022243_change_item_count_default_to_0.rb
@@ -1,0 +1,5 @@
+class ChangeItemCountDefaultTo0 < ActiveRecord::Migration
+  def change
+    change_column_default(:todo_lists, :item_count, 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160304031920) do
+ActiveRecord::Schema.define(version: 20160305022243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20160304031920) do
 
   create_table "todo_lists", force: :cascade do |t|
     t.string   "code"
-    t.integer  "item_count",   default: 1
+    t.integer  "item_count",   default: 0
     t.datetime "last_changed"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false

--- a/spec/models/todo_list_spec.rb
+++ b/spec/models/todo_list_spec.rb
@@ -4,4 +4,23 @@ RSpec.describe TodoList, type: :model do
   it "exists" do
     expect(TodoList).not_to be_nil
   end
+  describe "#item_added" do
+    let!(:todo_list) do
+      TodoList.create(code: TodoList.generate_code,
+                      item_count: 3,
+                      last_changed: Time.now - 10 * 60 * 60)
+    end
+    it "increments item_count by 1" do
+      old_item_count = todo_list.item_count
+
+      todo_list.item_added
+      expect(todo_list.item_count).to eq(old_item_count + 1)
+    end
+    it "changes last_changed current time" do
+      old_last_changed = todo_list.last_changed
+
+      todo_list.item_added
+      expect(todo_list.last_changed).not_to eq(old_last_changed)
+    end
+  end
 end

--- a/spec/models/todo_list_validations_spec.rb
+++ b/spec/models/todo_list_validations_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe TodoList, type: :model do
       expect(todo_list2).not_to be_valid
     end
 
-    it "defaults to item_count as 1" do
+    it "defaults to item_count as 0" do
       no_item_count = valid_attributes
       no_item_count.delete(:item_count)
 
       list = TodoList.create(no_item_count)
 
-      expect(list.item_count).to eq(1)
+      expect(list.item_count).to eq(0)
     end
 
     it "does not require a last_changed date " do


### PR DESCRIPTION
This 
- adds a migration to  change the default value of TodoList.item_count to be 0 instead of 1
- updated validation testing for TodoList to reflect previous change
- adds a model test for TodoList#item_added
