### PR TITLE
Updates TodoList model, seedfile and tests closes #30

### DIFF
--- a/db/migrate/20160307035121_delete_item_count.rb
+++ b/db/migrate/20160307035121_delete_item_count.rb
@@ -1,0 +1,5 @@
+class DeleteItemCount < ActiveRecord::Migration
+  def change
+    remove_column :todo_lists, :item_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160305022243) do
+ActiveRecord::Schema.define(version: 20160307035121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,10 +30,9 @@ ActiveRecord::Schema.define(version: 20160305022243) do
 
   create_table "todo_lists", force: :cascade do |t|
     t.string   "code"
-    t.integer  "item_count",   default: 0
     t.datetime "last_changed"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   add_index "todo_lists", ["code"], name: "index_todo_lists_on_code", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,5 @@ todo_list_count.times do |todo_list_num|
                  content: content,
                  show_time: show_time,
                  priority: [*1..5].sample)
-    todo_list.item_count += 1;
   end
 end

--- a/spec/models/todo_item_validations_spec.rb
+++ b/spec/models/todo_item_validations_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe TodoItem, type: :model do
     let!(:valid_attributes) do
       valid_list_attributes = {
         code: "valid code",
-        item_count: 42,
         last_changed: "Sat, 27 Feb 2016 22:39:42 UTC +00:00"
       }
       todo_list = TodoList.create(valid_list_attributes)

--- a/spec/models/todo_list_spec.rb
+++ b/spec/models/todo_list_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe TodoList, type: :model do
   describe "#items_changed" do
     before(:each) do
       @todo_list = TodoList.create(code: TodoList.generate_code,
-                      item_count: 3,
                       last_changed: Time.now - 10 * 60 * 60)
     end
     it "changes last_changed to current time" do

--- a/spec/models/todo_list_validations_spec.rb
+++ b/spec/models/todo_list_validations_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe TodoList, type: :model do
    let!(:valid_attributes) do
      {
        code: "valid code",
-       item_count: 42,
        last_changed: "Sat, 27 Feb 2016 22:39:42 UTC +00:00"
      }
    end
@@ -32,15 +31,6 @@ RSpec.describe TodoList, type: :model do
       todo_list2 = TodoList.new(non_unique_code)
 
       expect(todo_list2).not_to be_valid
-    end
-
-    it "defaults to item_count as 0" do
-      no_item_count = valid_attributes
-      no_item_count.delete(:item_count)
-
-      list = TodoList.create(no_item_count)
-
-      expect(list.item_count).to eq(0)
     end
 
     it "does not require a last_changed date " do


### PR DESCRIPTION
This removes the item_count column and attribute of the TodoList model. Originally this column was intended for improvement in performance. Since the field will not be needed in the future there is no reason to have it or test against it
